### PR TITLE
Set sandpaper lang automatically

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,5 @@ Imports:
     sandpaper,
     usethis,
     utils,
-    withr
+    withr,
+    yaml

--- a/R/render.R
+++ b/R/render.R
@@ -143,6 +143,16 @@ render_trans_from_branch <- function(
     clean = clean
   )
 
+  # Set lesson lang to 'lang' so that sandpaper elements are translated as well
+  withr::with_dir(
+    temp_dir,
+    {
+      conf <- yaml::read_yaml("config.yaml")
+      conf$lang <- lang
+      yaml::write_yaml(conf, "config.yaml")
+    }
+  )
+
   # Render lesson
   withr::with_dir(
     temp_dir,
@@ -234,6 +244,16 @@ render_trans_from_dir <- function(
     l10n_branch = NULL,
     lang = lang,
     clean = FALSE
+  )
+
+  # Set lesson lang to 'lang' so that sandpaper elements are translated as well
+  withr::with_dir(
+    temp_dir,
+    {
+      conf <- yaml::read_yaml("config.yaml")
+      conf$lang <- lang
+      yaml::write_yaml(conf, "config.yaml")
+    }
   )
 
   # Render lesson

--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -3,12 +3,12 @@
     Code
       keypoints_contents
     Output
-      [1] "<div id=\"keypoints1\" class=\"callout keypoints\">\n<div class=\"callout-square\">\n<i class=\"callout-icon\" data-feather=\"key\"></i>\n</div>\n<div class=\"callout-inner\">\n<h3 class=\"callout-title\">Keypoints<a class=\"anchor\" aria-label=\"anchor\" href=\"#keypoints1\"></a>\n</h3>\n<div class=\"callout-content\">\n<ul>\n<li>内容が変わらないエピソードには <code>.md</code>\nファイルを使用します。</li>\n<li>コードによって内容を計算する場合は <code>.Rmd</code>\nファイルを使用します。</li>\n<li>\n<code>sandpaper::check_lesson()</code>\nを実行することによってでレッスンの問題を特定します。</li>\n<li>\n<code>sandpaper::build_lesson()</code>\nを実行することによってレッスンをローカルでプレビューできます。</li>\n</ul>\n</div>\n</div>\n</div>"
+      [1] "<div id=\"keypoints1\" class=\"callout keypoints\">\n<div class=\"callout-square\">\n<i class=\"callout-icon\" data-feather=\"key\"></i>\n</div>\n<div class=\"callout-inner\">\n<h3 class=\"callout-title\">まとめ<a class=\"anchor\" aria-label=\"アンカー\" href=\"#keypoints1\"></a>\n</h3>\n<div class=\"callout-content\">\n<ul>\n<li>内容が変わらないエピソードには <code>.md</code>\nファイルを使用します。</li>\n<li>コードによって内容を計算する場合は <code>.Rmd</code>\nファイルを使用します。</li>\n<li>\n<code>sandpaper::check_lesson()</code>\nを実行することによってでレッスンの問題を特定します。</li>\n<li>\n<code>sandpaper::build_lesson()</code>\nを実行することによってレッスンをローカルでプレビューできます。</li>\n</ul>\n</div>\n</div>\n</div>"
 
 # translation works with locale dir
 
     Code
       keypoints_contents
     Output
-      [1] "<div id=\"keypoints1\" class=\"callout keypoints\">\n<div class=\"callout-square\">\n<i class=\"callout-icon\" data-feather=\"key\"></i>\n</div>\n<div class=\"callout-inner\">\n<h3 class=\"callout-title\">Keypoints<a class=\"anchor\" aria-label=\"anchor\" href=\"#keypoints1\"></a>\n</h3>\n<div class=\"callout-content\">\n<ul>\n<li>内容が変わらないエピソードには <code>.md</code>\nファイルを使用します。</li>\n<li>コードによって内容を計算する場合は <code>.Rmd</code>\nファイルを使用します。</li>\n<li>\n<code>sandpaper::check_lesson()</code>\nを実行することによってでレッスンの問題を特定します。</li>\n<li>\n<code>sandpaper::build_lesson()</code>\nを実行することによってレッスンをローカルでプレビューできます。</li>\n</ul>\n</div>\n</div>\n</div>"
+      [1] "<div id=\"keypoints1\" class=\"callout keypoints\">\n<div class=\"callout-square\">\n<i class=\"callout-icon\" data-feather=\"key\"></i>\n</div>\n<div class=\"callout-inner\">\n<h3 class=\"callout-title\">まとめ<a class=\"anchor\" aria-label=\"アンカー\" href=\"#keypoints1\"></a>\n</h3>\n<div class=\"callout-content\">\n<ul>\n<li>内容が変わらないエピソードには <code>.md</code>\nファイルを使用します。</li>\n<li>コードによって内容を計算する場合は <code>.Rmd</code>\nファイルを使用します。</li>\n<li>\n<code>sandpaper::check_lesson()</code>\nを実行することによってでレッスンの問題を特定します。</li>\n<li>\n<code>sandpaper::build_lesson()</code>\nを実行することによってレッスンをローカルでプレビューできます。</li>\n</ul>\n</div>\n</div>\n</div>"
 


### PR DESCRIPTION
This allows rendering a lesson in an alternative language without having to modify the source `config.yaml`.

This is particularly useful when a single repository contains all the translations, as described in https://discuss.ropensci.org/t/translating-carpentries-workbench-lessons-with-babeldown/3960, and as illustrated in https://github.com/epiverse-trace/tutorials-middle.

Happy to discuss alternative strategies but I figured showing the code may offer a clearer starting discussion point than an issue.

This would also make #25 obsolete.